### PR TITLE
Fix team name resolution in chrome extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,4 @@ cython_debug/
 
 # blobs from gamechanger
 *.json
+\!chrome-extension/manifest.json

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -1,0 +1,137 @@
+importScripts('parser.js');
+
+// Extract the game UUID from GC URLs, e.g.:
+//   /schedule/2339efef-0199-41db-b1fb-98581c19f726/plays
+function gameKeyFromUrl(url) {
+  const m = url.match(/\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\//i);
+  return m ? m[1] : url;
+}
+
+// Format a UTC timestamp into a readable local string for a given IANA timezone.
+// e.g. "2026-03-14T19:00:00.000Z" + "America/Los_Angeles" → "Sat Mar 14, 12:00 PM"
+function formatGameDate(startTs, timezone) {
+  try {
+    const d = new Date(startTs);
+    const str = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone || 'America/Los_Angeles',
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+    }).format(d);
+    // Intl gives "Sat, Mar 14, 12:00 PM" — drop the extra comma
+    return str.replace(',', '');
+  } catch {
+    return startTs;
+  }
+}
+
+// In-memory slots keyed by game UUID, accumulate data until we can process.
+const pending = {};
+
+function processGame(gameKey, timestamp) {
+  const slot = pending[gameKey];
+  if (!slot?.plays) return;
+
+  let result;
+  try {
+    result = parseGameData(slot.plays, slot.boxscore ?? null);
+  } catch (err) {
+    console.error('GC Extractor: parse error', err);
+    return;
+  }
+
+  // Determine home/away team IDs.
+  // slot.urlTeamId is the team whose page we navigated to.
+  // slot.homeAway ('home'/'away') tells us their role.
+  const urlTeamId = slot.urlTeamId;
+  const homeAway  = slot.homeAway;   // may be undefined if details not yet captured
+  const otherTeamId = result.teamIds.find(id => id !== urlTeamId);
+
+  let homeTeamId, awayTeamId;
+  if (homeAway === 'home') {
+    homeTeamId = urlTeamId;
+    awayTeamId = otherTeamId;
+  } else if (homeAway === 'away') {
+    homeTeamId = otherTeamId;
+    awayTeamId = urlTeamId;
+  } else {
+    // Details not captured yet — leave ordering undefined, will re-process later
+    homeTeamId = result.teamIds[0];
+    awayTeamId = result.teamIds[1];
+  }
+
+  // Resolve team names from captured metadata, fall back to player last names
+  const fallbackName = (teamId) => {
+    const p = Object.values(result.players).find(pl => pl.teamId === teamId);
+    return p ? p.last_name.split(' ')[0] : (teamId ?? '?').slice(0, 8);
+  };
+
+  const homeTeamName = (homeTeamId === urlTeamId ? slot.teamName : slot.opponentName)
+    ?? fallbackName(homeTeamId);
+  const awayTeamName = (awayTeamId === urlTeamId ? slot.teamName : slot.opponentName)
+    ?? fallbackName(awayTeamId);
+
+  const dateLabel = slot.startTs
+    ? formatGameDate(slot.startTs, slot.timezone)
+    : null;
+
+  const label = dateLabel
+    ? `${homeTeamName} vs ${awayTeamName} — ${dateLabel}`
+    : `${homeTeamName} vs ${awayTeamName}`;
+
+  const entry = {
+    id: gameKey,
+    gameKey,
+    timestamp,
+    label,
+    homeTeamId,
+    awayTeamId,
+    homeTeamName,
+    awayTeamName,
+    hasBoxscore: !!slot.boxscore,
+    result,
+  };
+
+  chrome.storage.local.get(['gcGames'], (stored) => {
+    const games = stored.gcGames || [];
+    const filtered = games.filter(g => g.gameKey !== gameKey);
+    const updated = [entry, ...filtered].slice(0, 20);
+    chrome.storage.local.set({ gcGames: updated, gcLatest: entry });
+  });
+}
+
+chrome.runtime.onMessage.addListener((message) => {
+  const { type, payload, url, teamId, timestamp } = message;
+  const KNOWN = ['GC_PLAYS_DATA', 'GC_BOXSCORE_DATA', 'GC_TEAM_DATA', 'GC_GAME_DETAILS'];
+  if (!KNOWN.includes(type)) return;
+
+  const gameKey = gameKeyFromUrl(url);
+  if (!pending[gameKey]) pending[gameKey] = {};
+  const slot = pending[gameKey];
+
+  // Always record the URL team ID when we have it
+  if (teamId) slot.urlTeamId = teamId;
+
+  switch (type) {
+    case 'GC_PLAYS_DATA':
+      slot.plays = payload;
+      break;
+    case 'GC_BOXSCORE_DATA':
+      slot.boxscore = payload;
+      break;
+    case 'GC_TEAM_DATA':
+      slot.teamName = payload.name;
+      break;
+    case 'GC_GAME_DETAILS':
+      slot.homeAway     = payload.home_away;
+      slot.opponentName = payload.opponent_team?.name;
+      slot.startTs      = payload.start_ts;
+      slot.timezone     = payload.timezone;
+      break;
+  }
+
+  processGame(gameKey, timestamp);
+});

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -1,0 +1,85 @@
+// Content script — runs in the extension's isolated world but can inject
+// scripts into the page context and listen for postMessage results.
+
+// Inject the interceptor into the actual page context
+const script = document.createElement('script');
+script.src = chrome.runtime.getURL('gc-interceptor.js');
+(document.head || document.documentElement).appendChild(script);
+script.remove();
+
+const HANDLED_TYPES = new Set([
+  'GC_PLAYS_DATA', 'GC_BOXSCORE_DATA', 'GC_TEAM_DATA', 'GC_GAME_DETAILS',
+]);
+
+// Extract the team ID from URLs like /teams/{id}/...
+function urlTeamId() {
+  const m = window.location.pathname.match(/\/teams\/([^\/]+)\//);
+  return m ? m[1] : null;
+}
+
+// Extract game UUID from URLs like /schedule/{uuid}/plays
+function urlGameKey() {
+  const m = window.location.pathname.match(
+    /\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\//i
+  );
+  return m ? m[1] : null;
+}
+
+window.addEventListener('message', (event) => {
+  if (event.source !== window) return;
+  const type = event.data?.type;
+  if (!HANDLED_TYPES.has(type)) return;
+
+  try {
+    chrome.runtime.sendMessage({
+      type,
+      payload: event.data.payload,
+      url: window.location.href,
+      teamId: urlTeamId(),
+      timestamp: Date.now(),
+    });
+  } catch {}
+});
+
+// Proactively fetch team name and game details — the page doesn't always
+// request these endpoints when navigating directly to a game sub-page.
+// Content scripts share the page's cookies so auth is automatic.
+async function proactiveFetch(teamId, gameKey) {
+  const send = (type, payload) => {
+    try {
+      chrome.runtime.sendMessage({
+        type,
+        payload,
+        url: window.location.href,
+        teamId,
+        timestamp: Date.now(),
+      });
+    } catch {}
+  };
+
+  if (teamId) {
+    try {
+      const resp = await fetch(`https://api.team-manager.gc.com/public/teams/${teamId}`);
+      if (resp.ok) {
+        const data = await resp.json();
+        if (data?.name) send('GC_TEAM_DATA', data);
+      }
+    } catch {}
+  }
+
+  if (gameKey) {
+    try {
+      const resp = await fetch(
+        `https://api.team-manager.gc.com/public/game-stream-processing/${gameKey}/details?include=line_scores`
+      );
+      if (resp.ok) {
+        const data = await resp.json();
+        if (data?.opponent_team) send('GC_GAME_DETAILS', data);
+      }
+    } catch {}
+  }
+}
+
+const _teamId  = urlTeamId();
+const _gameKey = urlGameKey();
+if (_teamId || _gameKey) proactiveFetch(_teamId, _gameKey);

--- a/chrome-extension/gc-interceptor.js
+++ b/chrome-extension/gc-interceptor.js
@@ -1,0 +1,69 @@
+// Injected directly into the page context (not the extension context) so it
+// can intercept fetch and XMLHttpRequest before the page's own code runs.
+// Communicates results back via window.postMessage.
+
+(function () {
+  function classify(obj) {
+    if (!obj || typeof obj !== 'object') return null;
+    if (obj.team_players && Array.isArray(obj.plays)) return 'GC_PLAYS_DATA';
+    // Boxscore: object whose values have a `groups` array with pitching/lineup
+    const firstTeam = Object.values(obj)[0];
+    if (Array.isArray(firstTeam?.groups) &&
+        firstTeam.groups.some(g => g.category === 'pitching' || g.category === 'lineup')) {
+      return 'GC_BOXSCORE_DATA';
+    }
+    // Team info: {id, name, sport: "baseball", ...}
+    // Use !obj.opponent_team to distinguish from GC_GAME_DETAILS (which has that field).
+    // age_group is omitted from the check because it can be absent or null.
+    if (obj.id && obj.name && obj.sport === 'baseball' && !obj.opponent_team) {
+      return 'GC_TEAM_DATA';
+    }
+    // Game details: {id, opponent_team: {name}, home_away, start_ts, timezone}
+    if (obj.id && obj.opponent_team?.name && obj.home_away !== undefined && obj.start_ts) {
+      return 'GC_GAME_DETAILS';
+    }
+    return null;
+  }
+
+  function maybeDispatch(body) {
+    let parsed;
+    try {
+      parsed = typeof body === 'string' ? JSON.parse(body) : body;
+    } catch {
+      return;
+    }
+    const type = classify(parsed);
+    if (type) {
+      window.postMessage({ type, payload: parsed }, '*');
+    }
+  }
+
+  // --- Wrap fetch ---
+  const originalFetch = window.fetch;
+  window.fetch = async function (...args) {
+    const response = await originalFetch.apply(this, args);
+    const clone = response.clone();
+    clone.text().then(maybeDispatch).catch(() => {});
+    return response;
+  };
+
+  // --- Wrap XMLHttpRequest ---
+  const originalOpen = XMLHttpRequest.prototype.open;
+  const originalSend = XMLHttpRequest.prototype.send;
+
+  XMLHttpRequest.prototype.open = function (...args) {
+    this._gcUrl = args[1];
+    return originalOpen.apply(this, args);
+  };
+
+  XMLHttpRequest.prototype.send = function (...args) {
+    this.addEventListener('load', function () {
+      if (this.responseType === '' || this.responseType === 'text') {
+        maybeDispatch(this.responseText);
+      } else if (this.responseType === 'json') {
+        maybeDispatch(this.response);
+      }
+    });
+    return originalSend.apply(this, args);
+  };
+})();

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,0 +1,40 @@
+{
+  "manifest_version": 3,
+  "name": "GameChanger Pitch Count Extractor",
+  "version": "1.0.0",
+  "description": "Extracts pitcher and catcher stats from GameChanger for youth baseball league reporting",
+  "permissions": [
+    "storage",
+    "activeTab"
+  ],
+  "host_permissions": [
+    "https://*.gc.com/*",
+    "https://*.gamechanger.io/*"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "https://*.gc.com/*",
+        "https://*.gamechanger.io/*"
+      ],
+      "js": ["content.js"],
+      "run_at": "document_start"
+    }
+  ],
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "Pitch Count Extractor"
+  },
+  "web_accessible_resources": [
+    {
+      "resources": ["gc-interceptor.js"],
+      "matches": [
+        "https://*.gc.com/*",
+        "https://*.gamechanger.io/*"
+      ]
+    }
+  ]
+}

--- a/chrome-extension/parser.js
+++ b/chrome-extension/parser.js
@@ -1,0 +1,355 @@
+// Parses GameChanger plays JSON (and optionally boxscore JSON) into pitcher and
+// catcher stats for youth baseball league reporting.
+// Compatible with both the Chrome extension and Node.js for testing.
+
+const PITCH_EVENT_RE = /^(Ball \d+|Strike \d+ (looking|swinging)|Foul|In play)$/;
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+function countPitches(atPlateDetails) {
+  return atPlateDetails.filter(d => PITCH_EVENT_RE.test(d.template)).length;
+}
+
+function buildPlayerMap(teamPlayers) {
+  const players = {};
+  for (const [teamId, roster] of Object.entries(teamPlayers)) {
+    for (const player of roster) {
+      players[player.id] = { ...player, teamId };
+    }
+  }
+  return players;
+}
+
+// Numeric sort key for a half-inning string like "3-top" or "2-bottom".
+function inningHalfOrder(ih) {
+  const [inning, half] = ih.split('-');
+  return parseInt(inning) * 2 + (half === 'top' ? 0 : 1);
+}
+
+// "(C, SS, P)" → ['C', 'SS', 'P']
+function parsePositions(playerText) {
+  return (playerText || '')
+    .replace(/[()]/g, '')
+    .split(',')
+    .map(p => p.trim())
+    .filter(Boolean);
+}
+
+// ---------------------------------------------------------------------------
+// Pitcher detection from plays
+// ---------------------------------------------------------------------------
+
+function detectPitcher(play) {
+  // final_details "X pitching" is the most reliable signal — check it first.
+  for (const detail of play.final_details) {
+    const m = detail.template.match(/\$\{([^}]+)\} pitching/);
+    if (m) return m[1];
+  }
+  // Fall back to at_plate_details for mid-at-bat substitution events.
+  // "Lineup changed: X in at pitcher" is unambiguous.
+  // "X in for pitcher Y" means X entered the game replacing Y who was the pitcher,
+  // but X may be taking a different position — only use this when final_details
+  // gave no answer (i.e. the at-bat has no explicit "pitching" call, as happens
+  // when a pitcher change occurs mid-at-bat and the play result omits the name).
+  for (const detail of play.at_plate_details) {
+    let m = detail.template.match(/Lineup changed: \$\{([^}]+)\} in at pitcher/);
+    if (m) return m[1];
+    m = detail.template.match(/\$\{([^}]+)\} in for pitcher/);
+    if (m) return m[1];
+  }
+  return null;
+}
+
+function detectCatcherFromPlay(play) {
+  for (const detail of [...play.at_plate_details, ...play.final_details]) {
+    const m = detail.template.match(/catcher \$\{([^}]+)\}/);
+    if (m) return m[1];
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Boxscore helpers
+// ---------------------------------------------------------------------------
+
+function parseBoxscoreData(data) {
+  const pitchCounts = {};
+  for (const teamData of Object.values(data)) {
+    if (!teamData?.groups) continue;
+    const pitchingGroup = teamData.groups.find(g => g.category === 'pitching');
+    if (!pitchingGroup?.extra) continue;
+    const pitchStat = pitchingGroup.extra.find(e => e.stat_name === '#P');
+    if (!pitchStat?.stats) continue;
+    for (const { player_id, value } of pitchStat.stats) {
+      pitchCounts[player_id] = value;
+    }
+  }
+  return pitchCounts;
+}
+
+function looksLikeBoxscore(obj) {
+  if (!obj || typeof obj !== 'object') return false;
+  const firstTeam = Object.values(obj)[0];
+  return Array.isArray(firstTeam?.groups) &&
+    firstTeam.groups.some(g => g.category === 'pitching' || g.category === 'lineup');
+}
+
+// ---------------------------------------------------------------------------
+// Catcher innings from boxscore position sequences
+//
+// Each player_text entry is an ORDERED list of position STINTS (consecutive
+// innings at the same spot). The length of each stint (in innings) is unknown,
+// but we can use pitcher inning data as an anchor when available.
+//
+// For pitcher-catchers: we know exactly which half-innings they pitched, so we
+// can count the fielding innings before/after their pitching period and
+// distribute the pre/post stints proportionally.
+//
+// For catch-only players: distribute C stints proportionally across all
+// fielding innings. Ceiling is used to err on the over-reporting side (safer
+// for catcher-eligibility rules).
+// ---------------------------------------------------------------------------
+
+function computeCatcherInnings(
+  positions,        // ['C', '3B', 'P', ...]
+  fieldingHalves,   // sorted array of half-inning strings for this team
+  pitcherHalves     // Set of half-inning strings this player pitched (or null)
+) {
+  const cCount = positions.filter(p => p === 'C').length;
+  if (cCount === 0) return null;
+
+  const totalStints = positions.length;
+  const totalFielding = fieldingHalves.length;
+
+  if (!pitcherHalves || pitcherHalves.size === 0 || !positions.includes('P')) {
+    // No pitcher anchor: distribute C stints evenly, ceiling for safety.
+    return {
+      innings: Math.ceil(totalFielding * cCount / totalStints),
+      isEstimate: true,
+    };
+  }
+
+  // Pitcher anchor: split analysis into before-P and after-P segments.
+  const pitchSorted = [...pitcherHalves].sort((a, b) => inningHalfOrder(a) - inningHalfOrder(b));
+  const firstPitch = pitchSorted[0];
+  const lastPitch  = pitchSorted[pitchSorted.length - 1];
+  const firstPOrder = inningHalfOrder(firstPitch);
+  const lastPOrder  = inningHalfOrder(lastPitch);
+
+  const pIdx = positions.indexOf('P');
+  const beforeP = positions.slice(0, pIdx);
+  const afterP  = positions.slice(pIdx + 1);
+
+  const fieldingBeforeP = fieldingHalves.filter(h => inningHalfOrder(h) < firstPOrder);
+  const fieldingAfterP  = fieldingHalves.filter(h => inningHalfOrder(h) > lastPOrder);
+
+  let caught = 0;
+
+  // C stints before pitching period
+  const cBefore = beforeP.filter(p => p === 'C').length;
+  if (cBefore > 0) {
+    if (fieldingBeforeP.length === 0) {
+      // Game started with this player already pitching — catching was pre-game
+      // or data gap; give minimum 1 per C stint.
+      caught += cBefore;
+    } else {
+      caught += beforeP.length === 1 && cBefore === 1
+        ? fieldingBeforeP.length  // sole position before pitching → all those innings
+        : Math.ceil(fieldingBeforeP.length * cBefore / beforeP.length);
+    }
+  }
+
+  // C stints after pitching period
+  const cAfter = afterP.filter(p => p === 'C').length;
+  if (cAfter > 0) {
+    if (fieldingAfterP.length === 0) {
+      // Game ended during/after the catching stint — give minimum 1 per C stint.
+      caught += cAfter;
+    } else {
+      caught += afterP.length === 1 && cAfter === 1
+        ? fieldingAfterP.length
+        : Math.ceil(fieldingAfterP.length * cAfter / afterP.length);
+    }
+  }
+
+  // isEstimate = true when C is mixed with other positions in the same period,
+  // or when we had to fall back to the minimum-1 rule.
+  const isEstimate = (cBefore > 0 && (beforeP.length > cBefore || fieldingBeforeP.length === 0)) ||
+                     (cAfter  > 0 && (afterP.length  > cAfter  || fieldingAfterP.length  === 0));
+
+  return { innings: caught, isEstimate };
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+function parseGameData(playsData, boxscoreData = null) {
+  const players = buildPlayerMap(playsData.team_players);
+  const boxscorePitchCounts = boxscoreData ? parseBoxscoreData(boxscoreData) : {};
+
+  // ---- Pass 1: pitcher stats from plays --------------------------------
+  const pitcherStats = {};   // playerId -> { pitchesFromPlays, lastAbPitches, inningHalves }
+  const catcherHalvesFromPlays = {}; // playerId -> Set (half-innings with explicit ref)
+
+  const halfPitcher = { top: null, bottom: null };
+  let prevInningHalf = null;
+  let prevOuts = 0;
+
+  // Determine which half each team fields in (needed for catcher calc later)
+  // top fielding team = the team whose pitchers throw in the top half
+  const halfFieldingTeam = { top: null, bottom: null };
+
+  for (const play of playsData.plays) {
+    if (play.final_details.length === 0 && play.at_plate_details.length === 0) continue;
+
+    const inningHalf = `${play.inning}-${play.half}`;
+    if (inningHalf !== prevInningHalf) {
+      prevOuts = 0;
+      prevInningHalf = inningHalf;
+    }
+
+    const detectedPitcher = detectPitcher(play);
+    if (detectedPitcher) {
+      halfPitcher[play.half] = detectedPitcher;
+      if (!halfFieldingTeam[play.half] && players[detectedPitcher]) {
+        halfFieldingTeam[play.half] = players[detectedPitcher].teamId;
+      }
+    }
+    const currentPitcher = halfPitcher[play.half];
+
+    if (currentPitcher) {
+      if (!pitcherStats[currentPitcher]) {
+        pitcherStats[currentPitcher] = {
+          pitchesFromPlays: 0,
+          lastAbPitches: 0,
+          inningHalves: new Set(),
+        };
+      }
+      const stats = pitcherStats[currentPitcher];
+      const abPitches = countPitches(play.at_plate_details);
+      stats.lastAbPitches = abPitches;
+      stats.pitchesFromPlays += abPitches;
+      stats.inningHalves.add(inningHalf);
+    }
+
+    // Explicit catcher references in play events (caught stealing, etc.)
+    const catcherId = detectCatcherFromPlay(play);
+    if (catcherId) {
+      if (!catcherHalvesFromPlays[catcherId]) catcherHalvesFromPlays[catcherId] = new Set();
+      catcherHalvesFromPlays[catcherId].add(inningHalf);
+    }
+
+    prevOuts = play.outs;
+  }
+
+  // ---- Pitchers output array -------------------------------------------
+  const pitchers = Object.entries(pitcherStats)
+    .map(([id, stats]) => {
+      const player = players[id];
+      const totalPitches = boxscorePitchCounts[id] ?? stats.pitchesFromPlays;
+      return {
+        id,
+        name: player ? `${player.first_name} ${player.last_name}` : id,
+        number: player?.number ?? '?',
+        teamId: player?.teamId ?? 'unknown',
+        pitchCount: totalPitches,
+        lastAtBatStartPitchCount: totalPitches - stats.lastAbPitches,
+        inningsPitched: stats.inningHalves.size,
+        hasBoxscoreData: id in boxscorePitchCounts,
+      };
+    })
+    .sort((a, b) => b.pitchCount - a.pitchCount);
+
+  // ---- Catchers output array -------------------------------------------
+  // Build sorted fielding half-innings per team
+  const allHalves = [...new Set(
+    playsData.plays
+      .filter(p => p.final_details.length > 0 || p.at_plate_details.length > 0)
+      .map(p => `${p.inning}-${p.half}`)
+  )].sort((a, b) => inningHalfOrder(a) - inningHalfOrder(b));
+
+  // teamId (from plays) -> sorted list of half-innings THEY FIELD in
+  const teamFieldingHalves = {};
+  for (const [half, teamId] of Object.entries(halfFieldingTeam)) {
+    if (!teamId) continue;
+    if (!teamFieldingHalves[teamId]) teamFieldingHalves[teamId] = [];
+    const halvesForThisHalf = allHalves.filter(h => h.endsWith(half));
+    teamFieldingHalves[teamId].push(...halvesForThisHalf);
+  }
+  for (const arr of Object.values(teamFieldingHalves)) {
+    arr.sort((a, b) => inningHalfOrder(a) - inningHalfOrder(b));
+  }
+
+  let catchers = [];
+
+  if (boxscoreData) {
+    // Build a map from player ID → plays teamId for cross-referencing
+    const playerToPlaysTeam = {};
+    for (const [teamId, roster] of Object.entries(playsData.team_players)) {
+      for (const p of roster) playerToPlaysTeam[p.id] = teamId;
+    }
+
+    for (const [, teamData] of Object.entries(boxscoreData)) {
+      if (!teamData?.groups) continue;
+      const lineup = teamData.groups.find(g => g.category === 'lineup');
+      if (!lineup) continue;
+
+      for (const entry of lineup.stats) {
+        const positions = parsePositions(entry.player_text);
+        if (!positions.includes('C')) continue;
+
+        const playerId = entry.player_id;
+        const player = players[playerId] ||
+          teamData.players?.find(p => p.id === playerId);
+        const playsTeamId = playerToPlaysTeam[playerId];
+        const fieldingHalves = (playsTeamId && teamFieldingHalves[playsTeamId]) || [];
+
+        const pitcherHalves = pitcherStats[playerId]?.inningHalves ?? null;
+        const result = computeCatcherInnings(positions, fieldingHalves, pitcherHalves);
+
+        // Use the play-event count as a floor (it's exact for the innings detected)
+        const playsFloor = catcherHalvesFromPlays[playerId]?.size ?? 0;
+        const innings = result
+          ? Math.max(result.innings, playsFloor)
+          : playsFloor;
+
+        catchers.push({
+          id: playerId,
+          name: player ? `${player.first_name} ${player.last_name}` : playerId,
+          number: player?.number ?? '?',
+          teamId: playsTeamId ?? 'unknown',
+          positions,
+          inningsCaught: innings,
+          isEstimate: result?.isEstimate ?? (playsFloor === 0),
+        });
+      }
+    }
+  } else {
+    // Fallback: play-event catcher detection only
+    for (const [id, halvesSet] of Object.entries(catcherHalvesFromPlays)) {
+      const player = players[id];
+      catchers.push({
+        id,
+        name: player ? `${player.first_name} ${player.last_name}` : id,
+        number: player?.number ?? '?',
+        teamId: player?.teamId ?? 'unknown',
+        positions: [],
+        inningsCaught: halvesSet.size,
+        isEstimate: false,
+      });
+    }
+  }
+
+  catchers.sort((a, b) => b.inningsCaught - a.inningsCaught);
+
+  const teamIds = [...new Set(Object.values(players).map(p => p.teamId))];
+  return { pitchers, catchers, players, teamIds };
+}
+
+// Export for Node.js testing
+if (typeof module !== 'undefined') {
+  module.exports = { parseGameData, parseBoxscoreData, looksLikeBoxscore };
+}

--- a/chrome-extension/popup.html
+++ b/chrome-extension/popup.html
@@ -1,0 +1,203 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Pitch Count Extractor</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      font-size: 13px;
+      width: 560px;
+      max-height: 600px;
+      overflow-y: auto;
+      background: #f5f5f5;
+      color: #222;
+    }
+
+    header {
+      background: #1a3a5c;
+      color: #fff;
+      padding: 10px 14px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+    header h1 { font-size: 15px; font-weight: 600; }
+    header select {
+      font-size: 12px;
+      padding: 2px 6px;
+      border-radius: 4px;
+      border: none;
+      max-width: 200px;
+    }
+
+    #no-data {
+      padding: 24px;
+      text-align: center;
+      color: #666;
+      line-height: 1.6;
+    }
+    #no-data code {
+      background: #e8e8e8;
+      padding: 2px 6px;
+      border-radius: 3px;
+      font-size: 12px;
+    }
+
+    section {
+      margin: 10px;
+      background: #fff;
+      border-radius: 6px;
+      box-shadow: 0 1px 3px rgba(0,0,0,.1);
+      overflow: hidden;
+    }
+
+    section h2 {
+      background: #1a3a5c;
+      color: #fff;
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: .05em;
+      padding: 7px 12px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+    section h2 span.sub {
+      font-weight: 400;
+      opacity: .75;
+      text-transform: none;
+      letter-spacing: 0;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+    th {
+      background: #edf2f7;
+      font-size: 11px;
+      font-weight: 600;
+      color: #555;
+      text-align: right;
+      padding: 5px 10px;
+    }
+    th:first-child { text-align: left; }
+    td {
+      padding: 5px 10px;
+      text-align: right;
+      border-top: 1px solid #f0f0f0;
+    }
+    td:first-child { text-align: left; }
+    tr:hover td { background: #f7faff; }
+
+    .player-name { font-weight: 500; }
+    .player-num { color: #888; font-size: 11px; margin-left: 4px; }
+    .team-badge {
+      display: inline-block;
+      font-size: 10px;
+      padding: 1px 5px;
+      border-radius: 3px;
+      margin-left: 6px;
+      vertical-align: middle;
+    }
+    .team-a { background: #dbeafe; color: #1e40af; }
+    .team-b { background: #dcfce7; color: #166534; }
+
+    .pitch-count { font-weight: 700; font-size: 14px; }
+    .warn { color: #b45309; }
+    .danger { color: #dc2626; }
+
+    .catcher-note {
+      font-size: 11px;
+      color: #888;
+      padding: 6px 12px;
+      border-top: 1px solid #f0f0f0;
+    }
+
+    .actions {
+      display: flex;
+      gap: 6px;
+      padding: 8px 10px;
+    }
+    button {
+      flex: 1;
+      padding: 6px 10px;
+      font-size: 12px;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      background: #fff;
+      cursor: pointer;
+      transition: background .15s;
+    }
+    button:hover { background: #f0f0f0; }
+    button.primary {
+      background: #1a3a5c;
+      color: #fff;
+      border-color: #1a3a5c;
+    }
+    button.primary:hover { background: #14304e; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>⚾ Pitch Count Extractor</h1>
+    <select id="game-select" title="Select game"></select>
+  </header>
+
+  <div id="no-data">
+    <p>No game data captured yet.</p>
+    <p style="margin-top:8px">Navigate to a GameChanger game page and the play-by-play data will be captured automatically.</p>
+  </div>
+
+  <div id="content" style="display:none">
+    <div class="actions">
+      <button id="btn-copy-csv" class="primary">Copy CSV</button>
+      <button id="btn-copy-text">Copy Text</button>
+      <button id="btn-clear">Clear Data</button>
+    </div>
+
+    <section>
+      <h2>Pitchers <span class="sub" id="pitcher-subtitle"></span></h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Player</th>
+            <th title="Number of innings (half-innings) pitched in">Inn.</th>
+            <th title="Total pitches thrown">Pitches</th>
+            <th title="Running pitch count at the start of their last at-bat">Start of Last AB</th>
+          </tr>
+        </thead>
+        <tbody id="pitcher-rows"></tbody>
+      </table>
+    </section>
+
+    <p class="catcher-note" id="boxscore-note" style="display:none">
+      * Pitch count estimated from play-by-play (boxscore not yet captured). Navigate to the boxscore tab for accurate totals.
+    </p>
+
+    <section>
+      <h2>Catchers <span class="sub" id="catcher-subtitle"></span></h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Player</th>
+            <th title="Position sequence this game (in order)">Positions</th>
+            <th title="Innings caught (~&nbsp;= estimated from position sequence)">Inn. Caught</th>
+          </tr>
+        </thead>
+        <tbody id="catcher-rows"></tbody>
+      </table>
+      <p class="catcher-note">
+        * Innings caught are estimated from the boxscore position sequence and may not be exact.
+      </p>
+    </section>
+  </div>
+
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -1,0 +1,201 @@
+let currentGame = null;
+let allGames = [];
+
+// --- Team helpers ---
+function teamName(teamId, game) {
+  if (teamId === game.homeTeamId) return game.homeTeamName ?? 'Home';
+  if (teamId === game.awayTeamId) return game.awayTeamName ?? 'Away';
+  return teamId?.slice(0, 8) ?? '?';
+}
+
+function teamBadge(teamId, game) {
+  const isHome = teamId === game.homeTeamId;
+  const cls   = isHome ? 'team-a' : 'team-b';
+  const label = isHome ? (game.homeTeamName ?? 'Home') : (game.awayTeamName ?? 'Away');
+  return `<span class="team-badge ${cls}">${label}</span>`;
+}
+
+// Sort home team first, then by pitch count / innings within each team
+function sortHomeFirst(arr, game) {
+  return [...arr].sort((a, b) => {
+    const aHome = a.teamId === game.homeTeamId ? 0 : 1;
+    const bHome = b.teamId === game.homeTeamId ? 0 : 1;
+    return aHome - bHome;
+  });
+}
+
+// --- Pitch count colour coding (Little League thresholds) ---
+function pitchClass(count) {
+  if (count >= 66) return 'danger';
+  if (count >= 51) return 'warn';
+  return '';
+}
+
+// --- Render ---
+function render(game) {
+  if (!game) {
+    document.getElementById('no-data').style.display = '';
+    document.getElementById('content').style.display = 'none';
+    return;
+  }
+
+  document.getElementById('no-data').style.display = 'none';
+  document.getElementById('content').style.display = '';
+
+  const { pitchers, catchers } = game.result;
+
+  document.getElementById('pitcher-subtitle').textContent =
+    `(${pitchers.length} pitcher${pitchers.length !== 1 ? 's' : ''})`;
+
+  const missingBoxscore = pitchers.some(p => !p.hasBoxscoreData);
+  document.getElementById('boxscore-note').style.display = missingBoxscore ? '' : 'none';
+
+  // Pitchers — home team first, then away
+  const sortedPitchers = sortHomeFirst(pitchers, game);
+  const pitcherBody = document.getElementById('pitcher-rows');
+  pitcherBody.innerHTML = sortedPitchers.map(p => {
+    const cls = pitchClass(p.pitchCount);
+    const pitchDisplay = p.hasBoxscoreData ? p.pitchCount : `${p.pitchCount}*`;
+    return `<tr>
+      <td>
+        <span class="player-name">${p.name}</span>
+        <span class="player-num">#${p.number}</span>
+        ${teamBadge(p.teamId, game)}
+      </td>
+      <td>${p.inningsPitched}</td>
+      <td class="pitch-count ${cls}">${pitchDisplay}</td>
+      <td>${p.lastAtBatStartPitchCount}</td>
+    </tr>`;
+  }).join('');
+
+  document.getElementById('catcher-subtitle').textContent =
+    catchers.length > 0
+      ? `(${catchers.length} catcher${catchers.length !== 1 ? 's' : ''} identified)`
+      : '(none identified)';
+
+  // Catchers — home team first
+  const sortedCatchers = sortHomeFirst(catchers, game);
+  const catcherBody = document.getElementById('catcher-rows');
+  if (catchers.length === 0) {
+    catcherBody.innerHTML = '<tr><td colspan="3" style="color:#888;text-align:center;padding:10px">No catcher data — navigate to the boxscore tab to capture position data</td></tr>';
+  } else {
+    catcherBody.innerHTML = sortedCatchers.map(c => {
+      const innings = c.isEstimate ? `${c.inningsCaught}*` : String(c.inningsCaught);
+      const posDisplay = c.positions.length
+        ? c.positions.map(p => p === 'C' ? `<strong>${p}</strong>` : p).join(', ')
+        : '—';
+      return `<tr>
+        <td>
+          <span class="player-name">${c.name}</span>
+          <span class="player-num">#${c.number}</span>
+          ${teamBadge(c.teamId, game)}
+        </td>
+        <td style="font-size:11px;color:#555">${posDisplay}</td>
+        <td>${innings}</td>
+      </tr>`;
+    }).join('');
+  }
+}
+
+// --- Exports ---
+function buildCsv(game) {
+  const { pitchers, catchers } = game.result;
+  const lines = ['Type,Name,Number,Team,IP,Pitches,Start of Last AB,Positions,Innings Caught'];
+
+  for (const p of sortHomeFirst(pitchers, game)) {
+    lines.push(`Pitcher,${p.name},${p.number},${teamName(p.teamId, game)},${p.inningsPitched},${p.pitchCount},${p.lastAtBatStartPitchCount},,`);
+  }
+  for (const c of sortHomeFirst(catchers, game)) {
+    const innings = c.isEstimate ? `${c.inningsCaught}*` : String(c.inningsCaught);
+    lines.push(`Catcher,${c.name},${c.number},${teamName(c.teamId, game)},,,,"${c.positions.join(', ')}",${innings}`);
+  }
+  return lines.join('\n');
+}
+
+function buildText(game) {
+  const { pitchers, catchers } = game.result;
+  const lines = [game.label ?? '', 'PITCHERS', '---'];
+  lines.push(`${'Name'.padEnd(28)} ${'IP'.padStart(4)} ${'Pitches'.padStart(7)} ${'Last AB'.padStart(7)}`);
+
+  for (const p of sortHomeFirst(pitchers, game)) {
+    lines.push(
+      `${(p.name + ' #' + p.number).padEnd(28)} ${String(p.inningsPitched).padStart(4)} ${String(p.pitchCount).padStart(7)} ${String(p.lastAtBatStartPitchCount).padStart(7)}  ${teamName(p.teamId, game)}`
+    );
+  }
+
+  if (catchers.length > 0) {
+    lines.push('', 'CATCHERS', '---');
+    lines.push(`${'Name'.padEnd(28)} ${'Positions'.padEnd(22)} ${'Inn.'.padStart(4)}`);
+    for (const c of sortHomeFirst(catchers, game)) {
+      const innings = c.isEstimate ? `${c.inningsCaught}*` : String(c.inningsCaught);
+      lines.push(
+        `${(c.name + ' #' + c.number).padEnd(28)} ${c.positions.join(', ').padEnd(22)} ${innings.padStart(4)}  ${teamName(c.teamId, game)}`
+      );
+    }
+  }
+  return lines.join('\n');
+}
+
+async function copyText(text) {
+  await navigator.clipboard.writeText(text);
+}
+
+// --- Game selector ---
+function populateSelector(games) {
+  const sel = document.getElementById('game-select');
+  sel.innerHTML = '';
+  if (games.length === 0) {
+    sel.appendChild(Object.assign(document.createElement('option'), { textContent: 'No games' }));
+    return;
+  }
+  for (const game of games) {
+    const opt = document.createElement('option');
+    opt.value = game.gameKey ?? game.id;
+    opt.textContent = game.label ?? game.gameKey;
+    sel.appendChild(opt);
+  }
+}
+
+// --- Init ---
+chrome.storage.local.get(['gcGames'], (stored) => {
+  allGames = stored.gcGames || [];
+  populateSelector(allGames);
+  if (allGames.length > 0) {
+    currentGame = allGames[0];
+    render(currentGame);
+  } else {
+    render(null);
+  }
+});
+
+document.getElementById('game-select').addEventListener('change', (e) => {
+  const game = allGames.find(g => (g.gameKey ?? g.id) === e.target.value);
+  if (game) { currentGame = game; render(game); }
+});
+
+document.getElementById('btn-copy-csv').addEventListener('click', () => {
+  if (!currentGame) return;
+  copyText(buildCsv(currentGame)).then(() => {
+    const btn = document.getElementById('btn-copy-csv');
+    btn.textContent = 'Copied!';
+    setTimeout(() => { btn.textContent = 'Copy CSV'; }, 1500);
+  });
+});
+
+document.getElementById('btn-copy-text').addEventListener('click', () => {
+  if (!currentGame) return;
+  copyText(buildText(currentGame)).then(() => {
+    const btn = document.getElementById('btn-copy-text');
+    btn.textContent = 'Copied!';
+    setTimeout(() => { btn.textContent = 'Copy Text'; }, 1500);
+  });
+});
+
+document.getElementById('btn-clear').addEventListener('click', () => {
+  chrome.storage.local.remove(['gcGames', 'gcLatest'], () => {
+    allGames = [];
+    currentGame = null;
+    populateSelector([]);
+    render(null);
+  });
+});


### PR DESCRIPTION
## Summary
- Renamed `injected.js` → `gc-interceptor.js` so extension-initiated requests are easily identifiable in DevTools by initiator name
- Content script now proactively fetches team name and game details on page load, rather than relying solely on intercepting page-initiated requests (which don't always fire on game sub-pages)
- Corrected API base URL to `api.team-manager.gc.com` with proper endpoints for team data and game details

## Test plan
- [ ] Load extension, navigate directly to a game plays or boxscore page
- [ ] Open popup — team names should resolve correctly (not fall back to player last names)
- [ ] Check DevTools Network tab — proactive fetches should show `gc-interceptor.js` as initiator

🤖 Generated with [Claude Code](https://claude.com/claude-code)