### PR TITLE
Fix pitcher inning over-count when first play of inning omits pitcher name

### DIFF
--- a/chrome-extension/parser.js
+++ b/chrome-extension/parser.js
@@ -209,6 +209,9 @@ function parseGameData(playsData, boxscoreData = null) {
     if (inningHalf !== prevInningHalf) {
       prevOuts = 0;
       prevInningHalf = inningHalf;
+      // Reset so a new inning isn't credited to the previous inning's pitcher
+      // just because the first play's details don't mention the pitcher name.
+      halfPitcher[play.half] = null;
     }
 
     const detectedPitcher = detectPitcher(play);


### PR DESCRIPTION
## Summary

- When a new inning starts and the first play's details don't include a pitcher name, the parser was carrying over the previous inning's pitcher and crediting them with the new inning
- This caused a pitcher's `inningsPitched` to be inflated by 1 whenever their replacement wasn't first detected until the second or later play of the inning
- Fix: reset `halfPitcher[half]` at each inning boundary — credit only begins once the pitcher is explicitly identified within the new inning

## What's unaffected

- Pitch counts are not impacted when boxscore data is present (used as the authoritative source)
- Any plays before the first pitcher detection in a new inning are simply unattributed rather than mis-attributed to the wrong pitcher
- Mid-inning substitution detection is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)