### PR TITLE
Add GitHub Actions release workflow for Chrome extension

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Release Chrome Extension
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract version
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Patch manifest.json version
+        run: |
+          jq '.version = "${{ steps.version.outputs.version }}"' \
+            chrome-extension/manifest.json > /tmp/manifest.json
+          mv /tmp/manifest.json chrome-extension/manifest.json
+
+      - name: Create zip
+        run: |
+          cd chrome-extension
+          zip -r ../extension-v${{ steps.version.outputs.version }}.zip .
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: extension-v${{ steps.version.outputs.version }}.zip
+          generate_release_notes: true
+
+      - name: Upload to Chrome Web Store
+        uses: fregante/chrome-webstore-upload-action@v2
+        with:
+          extension-id: ${{ secrets.CHROME_EXTENSION_ID }}
+          client-id: ${{ secrets.CHROME_CLIENT_ID }}
+          client-secret: ${{ secrets.CHROME_CLIENT_SECRET }}
+          refresh-token: ${{ secrets.CHROME_REFRESH_TOKEN }}
+          zip-path: extension-v${{ steps.version.outputs.version }}.zip
+          publish: true


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release.yml` triggered on `v*` tag pushes
- Patches `manifest.json` version from the tag, zips the extension, and creates a GitHub Release with the zip attached
- Submits the zip to the Chrome Web Store via `fregante/chrome-webstore-upload-action@v2`

## Before first use
1. Manually upload the extension to the [Chrome Web Store Developer Dashboard](https://chrome.google.com/webstore/devconsole)
2. Add 4 repo secrets: `CHROME_EXTENSION_ID`, `CHROME_CLIENT_ID`, `CHROME_CLIENT_SECRET`, `CHROME_REFRESH_TOKEN`

## Test plan
- [ ] Merge this PR
- [ ] Run `git tag v1.0.0 && git push --tags`
- [ ] Confirm workflow runs in Actions tab
- [ ] Confirm GitHub Release is created with zip attached
- [ ] After secrets configured, confirm Chrome Web Store shows pending review

🤖 Generated with [Claude Code](https://claude.com/claude-code)